### PR TITLE
Added keys() method to retrieve keys of cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,27 @@ memored.size(function(err, size) {
 });
 ```
 
+### keys(callback)
+
+This function returns an array of the keys for objects in the cache.
+
+**Arguments**:
+
+- **callback** {Function} (required): Function to be called when keys calculation is complete. Callback arguments:
+	- _err_ {Error}: Optional error
+	- _keys_ {Array}: An array of strings for the keys of the entries in the cache.
+
+**Example**:
+
+```javascript
+memored.keys(function(err, keys) {
+	console.log('Cache keys:', keys);
+});
+```
+
 ### version
 
-This is an attribute wich provides module's version number
+This is an attribute which provides module's version number
 
 
 # Final note

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function _getCacheSize(message) {
 
 function _getCacheKeys(message) {
 	message.responseParams = {
-		size: Object.keys(cache)
+		keys: Object.keys(cache)
 	};
 	_sendMessageToWorker(message);
 }

--- a/spec/memored.spec.js
+++ b/spec/memored.spec.js
@@ -259,6 +259,52 @@ describe('Memored test suite', function() {
 				});
 			});
 		});
+        
+		describe('Memored - keys', function() {
+
+			it('Should return keys for entries in the cache', function(done) {
+                
+                // clean cache to ensure we're measuring against a fresh slate
+                memored.clean(function() {
+
+                    // create three users with different key prefixes
+    				memored.store('abc-user1', _createUser(), function(err, expirationTime) {
+        				memored.store('abc-user2', _createUser(), function(err, expirationTime) {
+            				memored.store('def-user3', _createUser(), function(err, expirationTime) {
+                                
+                                // find the keys for items in the cache
+        						memored.keys(function(err, keys) {
+                                    
+                                    // should be 3 keys total
+        							expect(keys.length).to.equal(3);
+                                    
+                                    // count the keys by prefix
+                                    var abcCount = 0;
+                                    var defCount = 0;
+                                    for (var i = 0; i < keys.length; i++) {
+                                        if (keys[i].indexOf("abc-") === 0) {
+                                            abcCount++;
+                                        } else if (keys[i].indexOf("def-") === 0) {
+                                            defCount++;
+                                        }
+                                    }
+                                    
+                                    // two keys that start with "abc-"
+                                    expect(abcCount).to.equal(2);
+                                    
+                                    // one key that starts with "def-"
+                                    expect(defCount).to.equal(1);                                    
+                                    
+                                    done();
+        						});
+            				});
+        				});
+    				});                    
+                });
+			});
+
+		});
+        
 	
 	}
 


### PR DESCRIPTION
Really great library!  Very useful and simple in that it's well-designed.  The callback nature of all of the cache operations is exactly how things should be done and fit the asynchronous nature of distributed cluster.  

For our project, we needed a keys() method to provide an array of the keys in the cache.  So I added this and hopefully it can be merged into the master branch and released.

Excellent work!  Thanks for making this available.
